### PR TITLE
Add DBHandler interface & implementation for JDBC

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,6 +20,11 @@ dependencies {
 	// MySQL Driver
 	compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.24'
 
+	// Apache Commons dependencies for JDBC connection pooling & extras
+	implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: '2.8.0'
+	implementation group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'
+
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/api/src/main/java/com/savaari/api/database/DBCPDataSource.java
+++ b/api/src/main/java/com/savaari/api/database/DBCPDataSource.java
@@ -1,0 +1,36 @@
+package com.savaari.api.database;
+
+import com.mysql.cj.jdbc.Driver;
+import org.apache.commons.dbcp2.BasicDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DBCPDataSource {
+    
+    private static BasicDataSource dataSource = new BasicDataSource();
+    
+    static {
+        dataSource.setUrl("jdbc:mysql://"
+                + "localhost/ride_hailing" + "?user=" + "root"
+                + "&password=" + "thisIsOurSDAProjectPassword" +
+                "&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=Asia/Karachi");
+        dataSource.setUsername("root");
+        dataSource.setPassword("thisIsOurSDAProjectPassword");
+        dataSource.setMinIdle(5);
+        dataSource.setMaxIdle(10);
+        try {
+            dataSource.setDriver((Driver) Class.forName("com.mysql.cj.jdbc.Driver").newInstance());
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+            e.printStackTrace();
+        }
+
+        dataSource.setMaxOpenPreparedStatements(100);
+    }
+    
+    public synchronized static Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+    
+    private DBCPDataSource(){ }
+}

--- a/api/src/main/java/com/savaari/api/database/DBHandler.java
+++ b/api/src/main/java/com/savaari/api/database/DBHandler.java
@@ -1,0 +1,4 @@
+package com.savaari.api.database;
+
+public interface DBHandler {
+}

--- a/api/src/main/java/com/savaari/api/database/DBHandlerFactory.java
+++ b/api/src/main/java/com/savaari/api/database/DBHandlerFactory.java
@@ -1,0 +1,48 @@
+package com.savaari.api.database;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class DBHandlerFactory {
+
+    private static DBHandlerFactory instance = null;
+
+    private DBHandlerFactory() {
+
+    }
+
+    public synchronized static DBHandlerFactory getInstance() {
+        if (instance == null) {
+            instance = new DBHandlerFactory();
+        }
+        return instance;
+    }
+
+    public DBHandler createDBHandler() {
+
+        Properties prop;
+        String propFileName = "config.properties";
+        InputStream inputStream;
+
+        try {
+            prop = new Properties();
+            inputStream = getClass().getClassLoader().getResourceAsStream(propFileName);
+
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
+            }
+
+            // Get property value
+            String dbHandlerClassName = prop.getProperty("dbHandler");
+
+            return (DBHandler) Class.forName(dbHandlerClassName).getDeclaredConstructor().newInstance();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/api/src/main/java/com/savaari/api/database/OracleDBHandler.java
+++ b/api/src/main/java/com/savaari/api/database/OracleDBHandler.java
@@ -1,0 +1,76 @@
+package com.savaari.api.database;
+
+import org.apache.commons.dbutils.DbUtils;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class OracleDBHandler implements DBHandler {
+
+    private static final String LOG_TAG = OracleDBHandler.class.getSimpleName();
+
+    public OracleDBHandler() {
+    }
+
+    /* Methods to close ResultSet, PreparedStatement, and Connection */
+    private void closeAll(Connection connection, PreparedStatement preparedStatement, ResultSet resultSet) {
+
+            closeResultSet(resultSet);
+            closeStatement(preparedStatement);
+            closeConnection(connection);
+    }
+
+    private void closeConnection(Connection connection) {
+        try {
+            if (connection != null){
+            DbUtils.close(connection);
+            }
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
+    }
+
+    private void closeStatement(PreparedStatement preparedStatement) {
+        try {
+            if (preparedStatement != null) {
+                DbUtils.close(preparedStatement);
+            }
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
+    }
+
+    private void closeResultSet(ResultSet resultSet) {
+        try {
+            if (resultSet != null) {
+                DbUtils.close(resultSet);
+            }
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        }
+    }
+    /* End of closing util methods*/
+
+    private static int executeUpdate(String query) {
+
+        int numRowsUpdated;
+
+        try {
+            Connection connection = DBCPDataSource.getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement(query);
+
+            numRowsUpdated = preparedStatement.executeUpdate();
+
+            preparedStatement.close();
+            connection.close();
+            return numRowsUpdated;
+        }
+        catch (Exception e) {
+            System.out.println("Exception in OracleDBHandler: executeUpdate");
+            e.printStackTrace();
+            return -1;
+        }
+    }
+}


### PR DESCRIPTION
- Use mySQL connector for connecting to database
- Use Apache Commons DBCP2 & DBUtils for connection pooling
- DBHandler interface defines DB access operations
- OracleDBHandler implements DBHandler for mySQL database